### PR TITLE
Removed trailing comma causing OIDC not to work

### DIFF
--- a/stable/semaphore/templates/configmap.yaml
+++ b/stable/semaphore/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
         {{- end }}
         {{- $_ := set $providers $provider $config }}
       {{- end }}
-      "oidc_providers": {{ $providers | toJson }},
+      "oidc_providers": {{ $providers | toJson }}
       {{- end }}
     }
 


### PR DESCRIPTION
When enabling OIDC using the config like this:

```
  values: |
    admin:
      create: false
    oidc:
      enable: true
      providers:
        keycloak:
          display_name: Keycloak
          provider_url: {{ .Values.spec.semaphore.oidc.issuer }}
          redirect_url: https://{{ .Values.spec.semaphore.host }}/api/auth/oidc/keycloak/redirect
          client_id: semaphore
          client_secret: {{ .Values.spec.keycloak.clients.semaphore.clientSecret | quote }}
          username_claim: preferred_username
          name_claim: preferred_username
          email_claim: email
```

It causes a problem in the configmap, with the json being invalid due to a trailing comma:

```
Starting semaphore server
Loading config
Could not decode configuration!
panic: invalid character '}' looking for beginning of object key string
```