### PR TITLE
potential trailing comma fix

### DIFF
--- a/stable/semaphore/templates/configmap.yaml
+++ b/stable/semaphore/templates/configmap.yaml
@@ -34,10 +34,10 @@ data:
         {{- end }}
         {{- $_ := set $providers $provider $config }}
       {{- end }}
-      "oidc_providers": {{ $providers | toJson }},
+      "oidc_providers": {{ $providers | toJson }}
       {{- end }}
       {{- if .Values.config.forwarded_env_vars }}
-      "forwarded_env_vars": [
+      ,"forwarded_env_vars": [
         {{- range $index, $val := .Values.config.forwarded_env_vars }}
           {{- if $index }}, {{ end }}"{{ $val }}"
         {{- end }}]


### PR DESCRIPTION
this makes it so the comma is only added in the case that you have those env vars specified, prepending it so that we don't have the case where it fails to parse