### PR TITLE
fix: Use fully qualified image names for CRI-O 1.34+ compatibility

### DIFF
--- a/stable/semaphore/templates/tests/test-connection.yaml
+++ b/stable/semaphore/templates/tests/test-connection.yaml
@@ -13,7 +13,7 @@ spec:
 
   containers:
     - name: wget
-      image: busybox
+      image: docker.io/library/busybox
       command:
         - wget
       args:

--- a/stable/semaphore/values.yaml
+++ b/stable/semaphore/values.yaml
@@ -15,7 +15,7 @@ config:
 
 image:
   # -- Image repository used by deployment
-  repository: semaphoreui/semaphore
+  repository: docker.io/semaphoreui/semaphore
 
   # -- Optional tag for the repository, defaults to app version
   tag: ""


### PR DESCRIPTION
## Summary

This PR updates the image names used in the Helm chart templates to use Fully Qualified Image Names (FQIN).

This change is necessary to ensure compatibility with Kubernetes clusters running the CRI-O 1.34 or later container runtime.

## Details

CRI-O 1.34+ has stricter validation and rejects container image pulls that use unqualified (short) names, leading to deployment failures.

The image repository is updated from the short form to the fully qualified form.

## Background

https://github.com/cri-o/cri-o/pull/9401
