### PR TITLE
feat(semaphore): add custom CA bundle support

### DIFF
--- a/stable/semaphore/README.md.gotmpl
+++ b/stable/semaphore/README.md.gotmpl
@@ -64,6 +64,16 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
+
+### Custom CA bundle for on-prem Git (appended to ca-certificates.crt)
+
+```yml
+customCertificates:
+  enabled: true
+  existingSecret: my-custom-ca
+  key: ca.crt
+  mountPath: /etc/ssl/certs/ca-certificates.crt
+```
 ```
 
 ### Bundled MariaDB

--- a/stable/semaphore/templates/deployment.yaml
+++ b/stable/semaphore/templates/deployment.yaml
@@ -76,9 +76,35 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.admin.create .Values.extraInitContainers }}
+      {{- if or .Values.admin.create .Values.extraInitContainers .Values.customCertificates.enabled }}
 
       initContainers:
+        {{- if .Values.customCertificates.enabled }}
+        - name: custom-ca-bundle
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.podSecurityContext }}
+
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              cp /etc/ssl/certs/ca-certificates.crt /work/ca-certificates.crt
+              printf '\n' >> /work/ca-certificates.crt
+              cat /custom-ca/{{ .Values.customCertificates.key }} >> /work/ca-certificates.crt
+
+          volumeMounts:
+            - name: custom-ca-src
+              mountPath: /custom-ca
+              readOnly: true
+            - name: custom-ca-bundle
+              mountPath: /work
+        {{- end }}
         {{- if or .Values.admin.create }}
         - name: admin
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}
@@ -265,6 +291,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.existingSecret | default (printf "%s-general" (include "semaphoreui.fullname" .)) }}
                   key: {{ .Values.secrets.accesskeyEncryptionKey }}
+            {{- if .Values.customCertificates.enabled }}
+            - name: SSL_CERT_FILE
+              value: {{ .Values.customCertificates.mountPath | quote }}
+            - name: REQUESTS_CA_BUNDLE
+              value: {{ .Values.customCertificates.mountPath | quote }}
+            - name: GIT_SSL_CAINFO
+              value: {{ .Values.customCertificates.mountPath | quote }}
+            {{- end }}
           {{- if or .Values.extraEnvSecrets .Values.extraEnvVariables }}
             {{- range $key, $value := .Values.extraEnvSecrets }}
             - name: {{ $key }}
@@ -300,6 +334,12 @@ spec:
             - name: config
               mountPath: /etc/semaphore/config.json
               subPath: config.json
+            {{- if .Values.customCertificates.enabled }}
+            - name: custom-ca-bundle
+              mountPath: {{ .Values.customCertificates.mountPath | quote }}
+              subPath: ca-certificates.crt
+              readOnly: true
+            {{- end }}
             - name: workdir
               mountPath: {{ .Values.general.tmpPath }}
             {{- if eq .Values.database.type "bolt" }}
@@ -470,6 +510,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.existingSecret | default (printf "%s-general" (include "semaphoreui.fullname" .)) }}
                   key: {{ .Values.secrets.accesskeyEncryptionKey }}
+            {{- if .Values.customCertificates.enabled }}
+            - name: SSL_CERT_FILE
+              value: {{ .Values.customCertificates.mountPath | quote }}
+            - name: REQUESTS_CA_BUNDLE
+              value: {{ .Values.customCertificates.mountPath | quote }}
+            - name: GIT_SSL_CAINFO
+              value: {{ .Values.customCertificates.mountPath | quote }}
+            {{- end }}
           {{- if or .Values.extraEnvSecrets .Values.extraEnvVariables }}
             {{- range $key, $value := .Values.extraEnvSecrets }}
             - name: {{ $key }}
@@ -520,6 +568,12 @@ spec:
             - name: config
               mountPath: /etc/semaphore/config.json
               subPath: config.json
+            {{- if .Values.customCertificates.enabled }}
+            - name: custom-ca-bundle
+              mountPath: {{ .Values.customCertificates.mountPath | quote }}
+              subPath: ca-certificates.crt
+              readOnly: true
+            {{- end }}
             - name: workdir
               mountPath: {{ .Values.general.tmpPath }}
             {{- if eq .Values.database.type "bolt" }}
@@ -557,6 +611,20 @@ spec:
         - name: config
           configMap:
             name: {{ include "semaphoreui.fullname" . }}-config
+        {{- if .Values.customCertificates.enabled }}
+        - name: custom-ca-src
+          {{- if .Values.customCertificates.existingSecret }}
+          secret:
+            secretName: {{ .Values.customCertificates.existingSecret }}
+          {{- else if .Values.customCertificates.existingConfigMap }}
+          configMap:
+            name: {{ .Values.customCertificates.existingConfigMap }}
+          {{- else }}
+          {{- required "customCertificates.existingSecret or customCertificates.existingConfigMap is required when customCertificates.enabled=true" "" }}
+          {{- end }}
+        - name: custom-ca-bundle
+          emptyDir: {}
+        {{- end }}
         - name: workdir
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/semaphore/values.schema.json
+++ b/stable/semaphore/values.schema.json
@@ -163,6 +163,31 @@
           }
         }
       }
+    },
+    "customCertificates": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable appending custom CA bundle into ca-certificates.crt for outbound TLS"
+        },
+        "existingSecret": {
+          "type": ["string", "null"],
+          "description": "Existing secret containing the CA bundle"
+        },
+        "existingConfigMap": {
+          "type": ["string", "null"],
+          "description": "Existing configmap containing the CA bundle"
+        },
+        "key": {
+          "type": "string",
+          "description": "Key in secret/configmap that holds the CA bundle"
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "Path where the combined CA bundle is mounted"
+        }
+      }
     }
   }
 }

--- a/stable/semaphore/values.yaml
+++ b/stable/semaphore/values.yaml
@@ -38,13 +38,13 @@ serviceAccount:
 
 # -- Defines dnsConfig for the deployment
 # dnsConfig:
-  # nameservers:      # List of IPs
-  #   - 1.1.1.1
-  # searches:         # Search domains
-  #   - ns1.svc.cluster.local
-  # options:          # Resolver options
-  #   - name: ndots
-  #     value: "2"
+# nameservers:      # List of IPs
+#   - 1.1.1.1
+# searches:         # Search domains
+#   - ns1.svc.cluster.local
+# options:          # Resolver options
+#   - name: ndots
+#     value: "2"
 
 # -- Update strategy for deployment
 updateStrategy:
@@ -157,6 +157,22 @@ secrets:
 
   # -- Existing secret to use for secrets
   existingSecret:
+
+customCertificates:
+  # -- Enable appending custom CA bundle into ca-certificates.crt for outbound TLS (e.g. on-prem git)
+  enabled: false
+
+  # -- Existing secret containing the CA bundle (required if enabled and no configmap)
+  existingSecret:
+
+  # -- Existing configmap containing the CA bundle (required if enabled and no secret)
+  existingConfigMap:
+
+  # -- Key in secret/configmap that holds the CA bundle
+  key: ca.crt
+
+  # -- Path where the combined CA bundle is mounted (ca-certificates.crt)
+  mountPath: /etc/ssl/certs/ca-certificates.crt
 
 general:
   # -- Host to access Semaphore
@@ -480,5 +496,4 @@ postgresql:
     serviceMonitor:
       # -- Enable service monitor for postgresql
       enabled: false
-
 ...


### PR DESCRIPTION
Adds Helm chart support for custom CA bundles by appending a provided certificate into ca-certificates.crt, wiring TLS/Git CA env vars, and documenting/validating the new values.