### PR TITLE
fix: use /api/ping for health probes and make probes configurable

### DIFF
--- a/stable/semaphore/Chart.yaml
+++ b/stable/semaphore/Chart.yaml
@@ -35,4 +35,4 @@ name: semaphore
 sources:
 - https://github.com/semaphoreui/semaphore
 type: application
-version: 16.0.11
+version: 16.0.12

--- a/stable/semaphore/templates/deployment.yaml
+++ b/stable/semaphore/templates/deployment.yaml
@@ -550,14 +550,10 @@ spec:
               protocol: TCP
 
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
 
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           {{- if .Values.resources }}
 
           resources:

--- a/stable/semaphore/values.yaml
+++ b/stable/semaphore/values.yaml
@@ -405,6 +405,18 @@ admin:
   # -- Existing secret to use for admin
   existingSecret:
 
+# -- Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /api/ping
+    port: http
+
+# -- Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /api/ping
+    port: http
+
 # -- Resources for the deployment
 resources:
   limits: {}


### PR DESCRIPTION
## Summary
- Change default liveness/readiness probe path from `/` to `/api/ping`, which doesn't require authentication and avoids restart loops behind authenticating reverse proxies
- Make probes fully configurable via `livenessProbe` and `readinessProbe` values, allowing users to customize paths, timeouts, thresholds, etc.
- Bump chart version to 16.0.12

## Test plan
- [x] `helm template` renders correct default probes with `/api/ping`
- [x] Probes are overridable via `--set livenessProbe.httpGet.path=/custom`
- [ ] `ct lint` passes
- [ ] `ct install` passes in kind cluster