### PR TITLE
fix: remove duplicated labels

### DIFF
--- a/stable/semaphore/templates/configmap.yaml
+++ b/stable/semaphore/templates/configmap.yaml
@@ -6,9 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/pvc.yaml
+++ b/stable/semaphore/templates/pvc.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
@@ -40,9 +37,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-admin.yaml
+++ b/stable/semaphore/templates/secret-admin.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-database.yaml
+++ b/stable/semaphore/templates/secret-database.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-email.yaml
+++ b/stable/semaphore/templates/secret-email.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-general.yaml
+++ b/stable/semaphore/templates/secret-general.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-ldap.yaml
+++ b/stable/semaphore/templates/secret-ldap.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-runner.yaml
+++ b/stable/semaphore/templates/secret-runner.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-slack.yaml
+++ b/stable/semaphore/templates/secret-slack.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}

--- a/stable/semaphore/templates/secret-telegram.yaml
+++ b/stable/semaphore/templates/secret-telegram.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "semaphoreui.labels" . | nindent 4 }}
-{{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
 {{- if  .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}


### PR DESCRIPTION
On some resources the labels were set twice. The labels set in the values are already in the helper method as last:

```tpl
{{/*
Create basic labels
*/}}
{{- define "semaphoreui.labels" -}}
helm.sh/chart: "{{ include "semaphoreui.chart" . }}"
app.kubernetes.io/name: "{{ include "semaphoreui.name" . }}"
app.kubernetes.io/instance: "{{ .Release.Name }}"
{{- if .Chart.AppVersion }}
app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
{{- end }}
app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
{{- with .Values.labels }}
{{ toYaml . }}
{{- end }}
{{- end -}}
```

---

As example, when rendering the chart with the following command:

```shell
helm template test semaphore-16.2.2.tgz --set labels.hello=world
```

We currently get a double `hello: world` label:

```yaml
# Source: semaphore/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap

metadata:
  name: test-semaphore-config
  namespace: default
  labels:
    helm.sh/chart: "semaphore-16.2.2"
    app.kubernetes.io/name: "semaphore"
    app.kubernetes.io/instance: "test"
    app.kubernetes.io/version: "2.18.3"
    app.kubernetes.io/managed-by: "Helm"
    hello: world
    hello: world
```